### PR TITLE
download script: errors and requirements

### DIFF
--- a/README-ripe-import.md
+++ b/README-ripe-import.md
@@ -24,7 +24,7 @@ AS entry per line, with the AS-prefix, e.g. ``AS123``.
 Usage
 =====
 
-Download data to a directory using the script `ripe_download`.
+Download data to a directory using the script `ripe_download`, the program `curl` is required for this.
 
 Call `ripe_import.py --help` or `ripe_diff.py --help`
 to see all command line options.

--- a/bin/ripe_download
+++ b/bin/ripe_download
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 d=`date +%F`
 mkdir $d
 cd $d

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import find_packages, setup
 
 REQUIRES = [
     'intelmq>=1.1.0',
+    'psycopg2',
 ]
 
 BOTS = []


### PR DESCRIPTION
ripe_download: Document curl requirement
ripe_download: Fail early
setup/requirements: add psycopg2