### PR TITLE
Optionally import RIPE routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-This is a fork to support uploading RIPE data into [Tuency](https://gitlab.com/intevation/tuency/tuency)
-___
-
 # Two expert bots to lookup contact information in a database and apply notification rules
 
 Part of the [intelmq-cb-mailgen solution](https://github.com/Intevation/intelmq-mailgen-release).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This is a fork to support uploading RIPE data into [Tuency](https://gitlab.com/intevation/tuency/tuency)
+___
+
 # Two expert bots to lookup contact information in a database and apply notification rules
 
 Part of the [intelmq-cb-mailgen solution](https://github.com/Intevation/intelmq-mailgen-release).

--- a/bin/ripe_download
+++ b/bin/ripe_download
@@ -5,7 +5,7 @@ set -e
 d=`date +%F`
 mkdir $d
 cd $d
-for db in ripe.db.organisation.gz ripe.db.role.gz ripe.db.aut-num.gz ripe.db.inet6num.gz ripe.db.inetnum.gz
+for db in ripe.db.organisation.gz ripe.db.role.gz ripe.db.aut-num.gz ripe.db.inet6num.gz ripe.db.inetnum.gz ripe.db.route.gz ripe.db.route6.gz
  do
  echo "Downloading: " $db
  curl -O "https://ftp.ripe.net/ripe/dbase/split/$db"

--- a/intelmq_certbund_contact/ripe/ripe_data.py
+++ b/intelmq_certbund_contact/ripe/ripe_data.py
@@ -55,6 +55,14 @@ def add_common_args(parser):
     parser.add_argument("--inet6num-file",
                         default='ripe.db.inet6num.gz',
                         help=("Specify the inet6num data file."))
+    parser.add_argument("--route-file",
+                        default='ripe.db.route.gz',
+                        help=("Specify the route data file."))
+    parser.add_argument("--route6-file",
+                        default='ripe.db.route6.gz',
+                        help=("Specify the route6 data file."))
+    parser.add_argument("--import-route-data", action='store_true',
+                        help=("Whether to import/diff the route data."))
     parser.add_argument("--ripe-delegated-file",
                         default='delegated-ripencc-latest',
                         help=("Name of the delegated-ripencc-latest file to"
@@ -81,7 +89,7 @@ def load_ripe_files(options) -> tuple:
 
     Returns:
         tuple of (asn_list, organisation_list, role_list, abusec_to_org,
-                  inetnum_list, inet6num_list)
+                  inetnum_list, inet6num_list, route_list, route6_list)
     """
 
     # Step 1: read all files
@@ -122,6 +130,16 @@ def load_ripe_files(options) -> tuple:
                            ('role', 'nic-hdl', 'abuse-mailbox', 'org'),
                            verbose=options.verbose)
     role_index = build_index(role_list, 'nic-hdl')
+
+    route_list = []
+    route6_list = []
+    if options.import_route_data:
+        route_list = parse_file(options.route_file,
+                                ('route', 'origin'),
+                                verbose=options.verbose)
+        route6_list = parse_file(options.route6_file,
+                                 ('route6', 'origin'),
+                                 verbose=options.verbose)
 
     # Step 2: Prepare new data for insertion
 
@@ -166,7 +184,7 @@ def load_ripe_files(options) -> tuple:
 
 
     return (asn_list, organisation_list, role_list, abusec_to_org,
-            inetnum_list, inet6num_list)
+            inetnum_list, inet6num_list, route_list, route6_list)
 
 
 def read_delegated_file(filename, country, verbose=False):

--- a/intelmq_certbund_contact/ripe/ripe_import.py
+++ b/intelmq_certbund_contact/ripe/ripe_import.py
@@ -214,6 +214,12 @@ def main():
     ripe_data.add_db_args(parser)
     ripe_data.add_common_args(parser)
 
+    parser.add_argument("--before-commit-command",
+                        help=("SQL statement that is executed before committing"
+                              " the changes. This can be used to e.g. cleanup"
+                              " data that refers to the potentially changed"
+                              " RIPE data."))
+
     args = parser.parse_args()
 
     if args.verbose:
@@ -258,6 +264,13 @@ def main():
         if args.import_route_data:
             insert_new_routes(cur, route_list, 'route', args.verbose)
             insert_new_routes(cur, route6_list, 'route6', args.verbose)
+
+        # run "before commit command"
+        if args.before_commit_command:
+            if args.verbose:
+                print('Running before commit command...')
+                print('------------------------')
+            cur.execute(args.before_commit_command)
 
         # Commit all data
         con.commit()

--- a/intelmq_certbund_contact/ripe/ripe_import.py
+++ b/intelmq_certbund_contact/ripe/ripe_import.py
@@ -31,7 +31,7 @@ import psycopg2
 import psycopg2.extras
 import argparse
 import collections
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 import intelmq_certbund_contact.ripe.ripe_data as ripe_data
 
@@ -131,7 +131,7 @@ def insert_new_organisations(cur, organisation_list, verbose):
     return mapping
 
 def _generate_asn_entries(asn_list, mapping):
-    insert_time = datetime.now(tz=UTC)
+    insert_time = datetime.now(tz=timezone.utc)
     for entry in asn_list:
         org_id = mapping[entry["org"][0]].get("org_id")
         if org_id is None:
@@ -153,7 +153,7 @@ def insert_new_asn_org_entries(cur, asn_list, mapping):
     )
 
 def _generate_network_entries(org_net_mapping, mapping):
-    insert_time = datetime.now(tz=UTC)
+    insert_time = datetime.now(tz=timezone.utc)
     for org, networks in org_net_mapping.items():
         org_id = mapping[org].get("org_id")
         if org_id is None:
@@ -208,7 +208,7 @@ def insert_new_routes(cur, route_list, key, verbose):
     if verbose:
         print('** Saving {} data to database...'.format(key))
 
-    insert_time = datetime.now(tz=UTC)
+    insert_time = datetime.now(tz=timezone.utc)
 
     def _gen():
         for entry in route_list:

--- a/intelmq_certbund_contact/ripe/ripe_import.py
+++ b/intelmq_certbund_contact/ripe/ripe_import.py
@@ -221,7 +221,7 @@ def insert_new_routes(cur, route_list, key, verbose):
     psycopg2.extras.execute_values(
         cur,
         """INSERT INTO route_automatic
-                address, asn, import_source, import_time)
+                (address, asn, import_source, import_time)
             VALUES %s;""",
         _gen(),
         page_size=BULK_PAGE_SIZE,

--- a/sql/initdb.sql
+++ b/sql/initdb.sql
@@ -246,6 +246,23 @@ CREATE INDEX fqdn_annotation_fqdn_idx
           ON fqdn_annotation (fqdn_id);
 
 
+-- Routing information, useful as a mapping from network addresses to
+-- ASNs.
+CREATE TABLE route_automatic (
+    route_automatic_id SERIAL PRIMARY KEY,
+    address CIDR NOT NULL,
+    asn BIGINT NOT NULL,
+    LIKE automatic_templ INCLUDING ALL,
+
+    -- The data from ripe.db.route.gz and ripe.db.route6.gz has cases
+    -- where the same network address is associated with multiple ASNs,
+    -- so we cannot have a constraint on just (address, import_source).
+    UNIQUE (address, asn, import_source)
+);
+
+CREATE INDEX route_automatic_cidr_gist_idx ON route_automatic
+       USING gist (address inet_ops);
+
 
 -- Information about national CERTs
 

--- a/sql/update-route.sql
+++ b/sql/update-route.sql
@@ -1,0 +1,18 @@
+-- Update script for the route_automatic table.
+
+CREATE TABLE route_automatic (
+    route_automatic_id SERIAL PRIMARY KEY,
+    address CIDR NOT NULL,
+    asn BIGINT NOT NULL,
+    import_source VARCHAR(500) NOT NULL,
+    import_time TIMESTAMP NOT NULL,
+
+    -- explicitly name the constraint to make sure it has the same name
+    -- as the constraint created by initdb.sql.
+    CONSTRAINT automatic_templ_import_source_check CHECK (import_source <> ''),
+
+    UNIQUE (address, asn, import_source)
+);
+
+CREATE INDEX route_automatic_cidr_gist_idx ON route_automatic
+       USING gist (address inet_ops);


### PR DESCRIPTION
This PR propose merging an old change to optionally import RIPE routes, used in case of Tuency support. In addition, the query was updated to use bulk execution[1] to improve the overall performance. 

It requires `psycopg2` >= 2.7, which is already available even in distro packages [2]. 

[1] https://www.psycopg.org/docs/extras.html#psycopg2.extras.execute_values
[2] https://pkgs.org/search/?q=psycopg2