### PR TITLE
add contact expert tests, fix log syntax, handle empty extra

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -20,7 +20,9 @@ intelmq-certbund-contact (1.2.0-1) UNRELEASED; urgency=medium
   * Raise the minimum required python version to 3.10.
   * Add ERD (pgadmin) file for database design visualization.
   * RIPE import: validate the db connection credentials before loading the data for faster feedback to the user
-  * tests: add rules expert unittests
+  * tests:
+    * add rules expert unittests
+    * add tests for eventjson library
 
  -- Sebastian Wagner <swagner@intevation.de>  Wed, 05 Mar 2025 14:29:32 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -20,6 +20,7 @@ intelmq-certbund-contact (1.2.0-1) UNRELEASED; urgency=medium
   * Raise the minimum required python version to 3.10.
   * Add ERD (pgadmin) file for database design visualization.
   * RIPE import: validate the db connection credentials before loading the data for faster feedback to the user
+  * tests: add rules expert unittests
 
  -- Sebastian Wagner <swagner@intevation.de>  Wed, 05 Mar 2025 14:29:32 +0100
 

--- a/tests/certbund_contact/test_rules_expert.py
+++ b/tests/certbund_contact/test_rules_expert.py
@@ -84,6 +84,24 @@ class TestCERTBundRuleExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, NON_EMPTY_CERTBUND_EXAMPLE_OUTPUT)
 
+    def test_nonexisting_script_directory(self):
+        self.allowed_warning_count = 0
+        # not a directory
+        with self.assertRaisesRegex(ValueError, expected_regex='.*is not a directory or cannot be read.*'):
+            self.run_bot(parameters={'script_directory': '/dev/null'})
+        # missing read permissions
+        with self.assertRaisesRegex(ValueError, expected_regex='.*is not a directory or cannot be read.*'):
+            self.run_bot(parameters={'script_directory': '/root/.ssh/'})
+
+    def test_empty_script_directory(self):
+        """ Empty dir should give a warning, message should be passed through """
+        self.allowed_warning_count = 1  # No rules loaded
+        self.input_message = SOURCE_CONTACTS_EXAMPLE_OUTPUT
+        with TemporaryDirectory() as tempdir:
+            self.run_bot(parameters={'script_directory': tempdir})
+        self.assertMessageEqual(0, SOURCE_CONTACTS_EXAMPLE_OUTPUT)
+        self.assertLogMatches('No rules loaded\.', 'WARNING')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_eventjson.py
+++ b/tests/test_eventjson.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+"""
+Testing certbund_contact.eventjson
+"""
+
+import unittest
+from copy import deepcopy
+from json import dumps
+from intelmq.lib.message import Event
+
+import intelmq_certbund_contact.eventjson as eventjson
+
+
+SOURCE_CONTACTS_EXAMPLE_INPUT = {
+    "__type": "Event",
+    "comment": "foobar",
+    "extra.certbund": {
+        "source_contacts": {
+              "matches": [],
+              "organisations": []
+        }},
+    }
+
+SOURCE_CONTACTS_EXAMPLE_OUTPUT = {
+    "__type": "Event",
+    "comment": "foobar",
+    }
+
+EMPTY_SOURCE_DIRECTIVES_EXAMPLE_INPUT = {
+    "__type": "Event",
+    "comment": "foobar",
+    "extra.certbund": {"source_directives": []},
+    }
+
+EMPTY_SOURCE_DIRECTIVES_EXAMPLE_OUTPUT = SOURCE_CONTACTS_EXAMPLE_OUTPUT
+
+NON_EMPTY_CERTBUND_EXAMPLE_INPUT = {
+    "__type": "Event",
+    "comment": "foobar",
+    "extra.certbund": {"foo": "bar"},
+    }
+
+NON_EMPTY_CERTBUND_EXAMPLE_OUTPUT = NON_EMPTY_CERTBUND_EXAMPLE_INPUT
+
+
+def del_certbund_field(event, key):
+    """
+    A better testable version of the function: has a return value
+    """
+    new_event = deepcopy(event)
+    eventjson.del_certbund_field(new_event, key)
+    return new_event
+
+
+class TestEventJSON(unittest.TestCase):
+    """
+    A TestCase for intelmq_certbund_contact.eventjson.
+    """
+
+    def test_del_certbund_field(self):
+        # should do nothing
+        event = Event({'comment': '1'})
+        self.assertEqual(del_certbund_field(event, '2'), event)
+        event = Event({'extra': dumps({'comment': '2'})})
+        self.assertEqual(del_certbund_field(event, '2'), event)
+        event = Event({'extra': dumps({'comment': '2'})})
+        self.assertEqual(del_certbund_field(event, '1'), event)
+        # should remove the field
+        event = Event({'extra': dumps({'certbund': {'a': 2}})})
+        self.assertEqual(del_certbund_field(event, 'a'), {})
+        event = Event({'extra': dumps({'certbund': {'a': 2}, 'blocklist': 'lorem'})})
+        self.assertEqual(del_certbund_field(event, 'a'), {'extra.blocklist': 'lorem'})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- rules expert: fix log line syntax
- tests: rename contact tests file
- contact expert: handle empty extra field: an exception was thrown when adding an empty extra field
- tests: add contact expert tests 

requires https://github.com/Intevation/intelmq-mailgen/pull/54